### PR TITLE
Update serialization in storage reduce.

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -114,7 +114,7 @@ class _StorageBase:
 
     def __reduce__(self):
         b = io.BytesIO()
-        torch.save(self, b, _use_new_zipfile_serialization=False)
+        torch.save(self, b)
         return (_load_from_bytes, (b.getvalue(),))
 
     def __sizeof__(self):
@@ -901,7 +901,7 @@ class TypedStorage:
 
     def __reduce__(self):
         b = io.BytesIO()
-        torch.save(self, b, _use_new_zipfile_serialization=False)
+        torch.save(self, b)
         return (_load_from_bytes, (b.getvalue(),))
 
     def data_ptr(self):


### PR DESCRIPTION
The serialization protocol used in the reduce method of the current storage object is the lagecy protocol, and it is better to update it to the default zip new protocol
